### PR TITLE
Add form validation

### DIFF
--- a/views/dataset.hbs
+++ b/views/dataset.hbs
@@ -72,6 +72,7 @@
                                 <input type="file"
                                        class="form-control-file"
                                        name="dataset"
+                                       accept=".json"
                                        required>
                             </div>
                         </div>

--- a/views/evaluation.hbs
+++ b/views/evaluation.hbs
@@ -59,11 +59,15 @@
                                                 {{#if @last}}
                                                 {{this}}
                                                 {{else}}
-                                                {{this}} <input class="evaluation__form--word-input"
+                                                {{this}} <input
+                                                       class="evaluation__form--word-input evaluation-gapfill-word"
                                                        name="{{@index}}"
-                                                       required />
+                                                       required
+                                                       pattern="[a-zA-Z]+"
+                                                       title="Must be a single word with no spaces" />
                                                 {{/if}}
-                                                {{/each}}</p>
+                                                {{/each}}
+                                            </p>
                                         </div>
                                     </div>
                                     <input type="hidden"


### PR DESCRIPTION
What's changed:
- Add form validation to only allow json files to be uploaded as a dataset
- When submitting words into the gap fill exercise only allow single words with characters a-z