### PR TITLE
Add translation without gaps in to the data set

### DIFF
--- a/src/dynamoDb/api.ts
+++ b/src/dynamoDb/api.ts
@@ -119,6 +119,7 @@ const putSegment = (segmentData: Segment): Promise<string> => {
       id: segmentData.id,
       translationSystem: segmentData.translationSystem,
       source: segmentData.source,
+      translation: segmentData.translation,
       hint: segmentData.hint,
       problem: segmentData.problem,
       gapDensity: segmentData.gapDensity,
@@ -161,6 +162,7 @@ const putSegmentAnswers = (segmentAnswer: SegmentAnswer): Promise<string> => {
       hint: segmentAnswer.hint,
       problem: segmentAnswer.problem,
       source: segmentAnswer.source,
+      translation: segmentAnswer.translation,
     },
     TableName: getSegmentSetAnswersTableName(),
   };
@@ -215,6 +217,7 @@ const convertAttributeMapToSegment = (
     item['id'],
     item['translationSystem'],
     item['source'],
+    item['translation'],
     item['hint'],
     item['problem'],
     item['gapDensity'],

--- a/src/models/models.ts
+++ b/src/models/models.ts
@@ -16,6 +16,7 @@ class Segment {
     public id: string,
     public translationSystem: string,
     public source: string,
+    public translation: string,
     public hint: string,
     public problem: string,
     public gapDensity: string,
@@ -40,6 +41,7 @@ class SegmentAnswer {
     public hint: string,
     public problem: string,
     public source: string,
+    public translation: string,
     answerId?: string
   ) {
     this.answerId = answerId === undefined ? uuidv1() : answerId;

--- a/src/models/requests.ts
+++ b/src/models/requests.ts
@@ -14,6 +14,7 @@ interface SegmentEvaluationRequestBody {
   hint: string;
   problem: string;
   source: string;
+  translation: string;
 }
 
 interface SegmentEvaluationRequest extends Request {

--- a/src/routes/evaluation.ts
+++ b/src/routes/evaluation.ts
@@ -32,7 +32,8 @@ const buildEvaluationRoutes = (app: Application) => {
         body.correctAnswers,
         body.hint,
         body.problem,
-        body.source
+        body.source,
+        body.translation
       )
     )
       .then(() =>
@@ -78,6 +79,7 @@ const buildEvaluationRoutes = (app: Application) => {
                 sourceLanguage: segment.sourceLanguage,
                 translationSystem: segment.translationSystem,
                 correctAnswers: segment.correctAnswers,
+                translation: segment.translation,
               });
             })
             .catch(error => {

--- a/views/dataset.hbs
+++ b/views/dataset.hbs
@@ -47,6 +47,7 @@
                             "id": "string",
                             "translationSystem": "string",
                             "source": "string",
+                            "translation": "string",
                             "hint": "string",
                             "problem": "string",
                             "gapDensity": "string",

--- a/views/evaluation.hbs
+++ b/views/evaluation.hbs
@@ -112,6 +112,9 @@
                                     <input type="hidden"
                                            name='source'
                                            value='{{source}}' />
+                                    <input type="hidden"
+                                           name='translation'
+                                           value='{{translation}}' />
                                     <div class="row justify-content-center form-group">
                                         <div class="col-sm-2">
                                             <button type="submit"


### PR DESCRIPTION
What's changed:
- When exporting the answers given for the gap fills the complete translated sentence without gaps in also needs to be returned. This adds the translation into the data model.