### PR TITLE
bug: explicitly set target for TypeScript compiler

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "target": "es5",
     "lib": ["es6"],
     "module": "commonjs",
     "noImplicitReturns": true,


### PR DESCRIPTION
Fix for:

`error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.`