### PR TITLE
Update copy for start of gap fill exercise

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -5,6 +5,7 @@ import { Instance } from 'multer';
 
 import { loadConfig } from './config';
 import { buildIndexRoute } from './routes/index';
+import { buildInstructionsRoute } from './routes/instructions';
 import { buildStartRoute } from './routes/start';
 import { buildBeginEvaluationRoute } from './routes/beginEvaluation';
 import { buildEvaluationRoutes } from './routes/evaluation';
@@ -33,6 +34,7 @@ app.set('view engine', 'hbs');
 const upload: Instance = multer({ dest: 'uploads/' });
 
 buildIndexRoute(app);
+buildInstructionsRoute(app);
 buildStartRoute(app);
 buildBeginEvaluationRoute(app);
 buildEvaluationRoutes(app);

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -2,7 +2,18 @@ import { Application, Request, Response } from 'express';
 
 const buildIndexRoute = (app: Application) => {
   app.get('/', (req: Request, res: Response) => {
-    res.render('index', {
+    res.render('instructions', {
+      title: 'Gap Fill Evaluation Task',
+      paragraphs: [
+        'Thank you for agreeing to act as an evaluator for the Gourmet neural language project.',
+        'The evaluation you are taking part in is a gap filling exercise.',
+        'You will be shown a series of 30 sentences taken from either BBC or DW news output. Each sentence will have either a single word or multiple words missing, each replaced by a gap.',
+        'Each gap holds the position of a single word only.',
+        'Your task is to try to recreate the original news sentences by filling in the gap left by each missing word with the word you believe most likely to have been removed.',
+        'On the next page you will receive specific instructions to carry out this evaluation.',
+        'If you are happy to proceed please click ‘OK’.',
+      ],
+      formSubmissionUrl: '/instructions',
       datasetSubmissionUrl: '/dataset',
       exportDataUrl: '/exportData',
     });

--- a/src/routes/instructions.ts
+++ b/src/routes/instructions.ts
@@ -1,0 +1,22 @@
+import { Application, Request, Response } from 'express';
+
+const buildInstructionsRoute = (app: Application) => {
+  app.get('/instructions', (req: Request, res: Response) => {
+    res.render('instructions', {
+      title: 'PLEASE READ',
+      paragraphs: [
+        'In some evaluations participants will be presented with hint sentences. If you are provided with these please refer to them to aid your decision. ',
+        'In others you’ll be on your own with just the rest of the sentence as context to guide you. Make your best guess.',
+        'You can of course use your own knowledge to fill the gaps but please do not conduct research or speak to others for help.',
+        'If you have no hint and really no idea just give it your best shot. However please avoid using words you suspect are not correct to give an amusing outcome!',
+        'Please fill all gaps.',
+        'If you have read the above and are happy to proceed please click ‘OK’.',
+      ],
+      formSubmissionUrl: '/start',
+      datasetSubmissionUrl: '/dataset',
+      exportDataUrl: '/exportData',
+    });
+  });
+};
+
+export { buildInstructionsRoute };

--- a/views/instructions.hbs
+++ b/views/instructions.hbs
@@ -26,22 +26,17 @@
         <div class="container">
             <div class="row align-items-center">
                 <div class="col margin-top-5percent">
-                    <h1 class="text-center text-primary-mid-green">Gap Fill Evaluation Task</h1>
+                    <h1 class="text-center text-primary-mid-green">{{title}}</h1>
                     <div class="row justify-content-center">
                         <div class="col-sm-8 margin-top-5percent h4 text-primary-dark-grey">
-                            <p>Thank you for agreeing to act as an evaluator for the Gourmet neural language
-                                project.</p>
-                            <p>You will now be shown a series of 30 sentences. The sentence will have a number of gaps
-                                in it, please fill in the gap with a single word you believe to be most appropriate.
-                                Some sentences will be accompanied by a hint sentence. Please use this sentence to
-                                inform your decision on the most appropriate word. Some sentences will have no hint, in
-                                this case please make your best guess based on context alone.</p>
-                            <p>If you are happy to proceed please click ‘OK’.</p>
+                            {{#each paragraphs}}
+                            <p>{{this}}</p>
+                            {{/each}}
                         </div>
                     </div>
 
                     <form class="margin-top-5percent"
-                          action="/start"
+                          action="{{formSubmissionUrl}}"
                           method="GET">
                         <div class="row justify-content-center form-group">
                             <div class="col-md-2">

--- a/views/start.hbs
+++ b/views/start.hbs
@@ -26,18 +26,17 @@
         <div class="container">
             <div class="row align-items-center">
                 <div class="col">
-                    <h1 class="text-center text-primary-mid-green">Title</h1>
+                    <h1 class="text-center text-primary-mid-green">Gap Fill Evaluation Task</h1>
                     <div class="row justify-content-center">
                         <div class="col-sm-10 margin-top-5percent h5 text-primary-dark-grey">
-                            <p>The evaluation process is not timed and there is no time limit. However each test set
-                                should be completed in an unbroken single sitting.</p>
-                            <p>Please start the test set when you will be able to give it your full attention to
-                                completion.</p>
-                            <p>If you have been asked to complete multiple test sets you don’t need to do them in one
-                                continuous sitting.</p>
-                            <p>If you are ready to complete an evaluation now, select your ID and the test set you
-                                have been asked to do.</p>
+                            <p>The evaluation process is timed but there is no time limit.</p>
+                            <p>Please complete the evaluation in an unbroken single sitting.</p>
+                            <p>If you have been asked to complete multiple gap filling sessions you don’t need to do
+                                them in one continuous sitting.</p>
+                            <p>If you are ready to complete an evaluation now, select your ID and the test set you have
+                                been asked to do.</p>
                             <p>Thank you again for your time.</p>
+                            <p>If you are ready to begin now please click ‘Start Evaluation’.</p>
                         </div>
                     </div>
                     <form class="text-primary-dark-grey"


### PR DESCRIPTION
What's changed:
- Updated copy for the start of the test. Copy from Julie
- Added an additional page of instructions at the start of the test

Index page
![image](https://user-images.githubusercontent.com/6666113/72978474-6e38e080-3dce-11ea-9cca-dae3ed15c069.png)
Instructions page
![image](https://user-images.githubusercontent.com/6666113/72978510-7ee95680-3dce-11ea-8e0c-74cfc7858d5e.png)
Start page
![image](https://user-images.githubusercontent.com/6666113/72978589-a50ef680-3dce-11ea-9552-0f677c0f8f84.png)
