### PR TITLE
Add margin to ensure 'ok' button is still visible on smaller screens

### DIFF
--- a/public/main.css
+++ b/public/main.css
@@ -82,9 +82,17 @@ html {
   margin-top: 5vh;
 }
 
+.margin-bottom-7percent {
+  margin-bottom: 7vh;
+}
+
 .gourmet_logo {
   margin: 5vh;
   height: 5vh;
+}
+
+.instructions_font-size {
+  font-size: 1.2rem;
 }
 
 .evaluation__subtitle {

--- a/views/instructions.hbs
+++ b/views/instructions.hbs
@@ -23,14 +23,14 @@
             <img class="gourmet_logo"
                  src="./media/horizontal_light.png" />
         </div>
-        <div class="container">
+        <div class="container margin-bottom-7percent">
             <div class="row align-items-center">
                 <div class="col margin-top-5percent">
                     <h1 class="text-center text-primary-mid-green">{{title}}</h1>
                     <div class="row justify-content-center">
-                        <div class="col-sm-8 margin-top-5percent h4 text-primary-dark-grey">
+                        <div class="col-sm-10 margin-top-5percent h4 text-primary-dark-grey">
                             {{#each paragraphs}}
-                            <p>{{this}}</p>
+                            <p class="instructions_font-size">{{this}}</p>
                             {{/each}}
                         </div>
                     </div>


### PR DESCRIPTION
What's changed:
- Bug fix: Missing margin property meant on smaller screens the 'o.k' button wasn't visible on instruction pages
- Decrease font size so that the entire instruction text shows on a standard 13 inch screen