### PR TITLE
When displaying segment sets to user order them alphabetically by name

### DIFF
--- a/src/routes/start.ts
+++ b/src/routes/start.ts
@@ -5,7 +5,10 @@ const buildStartRoute = (app: Application) => {
   app.get('/start', (req: Request, res: Response) => {
     getSegmentSets()
       .then(segmentSets => {
-        res.render('start', { segmentSets, evaluatorIds });
+        const setsOrderedByName = segmentSets.sort((a, b) =>
+          a.name.localeCompare(b.name)
+        );
+        res.render('start', { segmentSets: setsOrderedByName, evaluatorIds });
       })
       .catch(error => {
         console.error(`Could not get segment sets ${error}`);


### PR DESCRIPTION
What's changed:
- Segment sets have a human readable name. When the user selects a segment set to evaluate the sets are now sorted in the dropdown alphabetically by the human readable name