### PR TITLE
Add autofocus to first gap to fill on evaluation pages

### DIFF
--- a/views/evaluation.hbs
+++ b/views/evaluation.hbs
@@ -67,6 +67,8 @@
                                                        required
                                                        autocomplete="off"
                                                        pattern="[a-zA-Z0-9]+"
+                                                       {{#if @first}}autofocus="autofocus"
+                                                       {{/if}}
                                                        title="Must be a single word with no spaces" />
                                                 {{/if}}
                                                 {{/each}}


### PR DESCRIPTION
What's changed:
- Add autofocus to first gap to fill on evaluation pages