### PR TITLE
feat: timestamp segment answers

### DIFF
--- a/src/dynamoDb/api.ts
+++ b/src/dynamoDb/api.ts
@@ -163,6 +163,7 @@ const putSegmentAnswers = (segmentAnswer: SegmentAnswer): Promise<string> => {
       problem: segmentAnswer.problem,
       source: segmentAnswer.source,
       translation: segmentAnswer.translation,
+      timestamp: Date.now(),
     },
     TableName: getSegmentSetAnswersTableName(),
   };


### PR DESCRIPTION
What's changed:

- Timestamping all segment set answers. There have been issues where evaluators have completed the evaluation sets more than once. This will allow us to take their first scores only
