### PR TITLE
Remove duplicates

### DIFF
--- a/src/dynamoDb/api.ts
+++ b/src/dynamoDb/api.ts
@@ -221,7 +221,8 @@ const convertAttributeMapToSegmentAnswer = (
     item['problem'],
     item['source'],
     item['translation'],
-    item['answerId']
+    item['answerId'],
+    Number(item['timestamp'] || -1)
   );
 };
 

--- a/src/models/models.ts
+++ b/src/models/models.ts
@@ -29,7 +29,8 @@ class Segment {
 }
 
 class SegmentAnswer {
-  public answerId?: string;
+  public answerId: string;
+  public timestamp: number;
   constructor(
     public segmentId: string,
     public evaluatorId: string,
@@ -42,9 +43,11 @@ class SegmentAnswer {
     public problem: string,
     public source: string,
     public translation: string,
-    answerId?: string
+    answerId?: string,
+    timestamp?: number
   ) {
     this.answerId = answerId === undefined ? uuidv1() : answerId;
+    this.timestamp = timestamp === undefined ? -1 : timestamp;
   }
 }
 
@@ -61,4 +64,31 @@ interface EvaluatorSet {
   evaluators: string;
 }
 
-export { SegmentSet, Segment, SegmentAnswer, DatasetFile, EvaluatorSet };
+class GapAnswer {
+  constructor(
+    public gapId: string,
+    public evaluatorId: string,
+    public sourceLanguage: string,
+    public segmentId: string,
+    public numOfGapsInSentence: number,
+    public translationSystem: string,
+    public correctAnswer: string,
+    public answerGiven: string,
+    public autoAnswerMatch: string,
+    public timeTaken: number,
+    public meanTimePerGap: number,
+    public problem: string,
+    public hint: string,
+    public translation: string,
+    public source: string
+  ) {}
+}
+
+export {
+  SegmentSet,
+  Segment,
+  SegmentAnswer,
+  DatasetFile,
+  EvaluatorSet,
+  GapAnswer,
+};

--- a/src/routes/__tests__/exportdata.test.ts
+++ b/src/routes/__tests__/exportdata.test.ts
@@ -1,0 +1,62 @@
+import { convertSegmentAnswerToGapAnswer } from '../exportData';
+import { SegmentAnswer, GapAnswer } from '../../models/models';
+
+describe('convertSegmentAnswerToGapAnswer', () => {
+  test('', () => {
+    const segmentAnswer = new SegmentAnswer(
+      'segmentId',
+      'evaluatorId1',
+      ['a', 'b'],
+      12,
+      'sourceLanguage',
+      'translationSystem',
+      ['a', 'b'],
+      'hint',
+      'problem',
+      'source',
+      'translation',
+      'answerId',
+      123
+    );
+
+    const expectedResult = [
+      new GapAnswer(
+        'segmentId_1',
+        'evaluatorId1',
+        'sourceLanguage',
+        'segmentId',
+        2,
+        'translationSystem',
+        'a',
+        'a',
+        'YES',
+        12,
+        6,
+        'problem',
+        'hint',
+        'translation',
+        'source'
+      ),
+      new GapAnswer(
+        'segmentId_2',
+        'evaluatorId1',
+        'sourceLanguage',
+        'segmentId',
+        2,
+        'translationSystem',
+        'b',
+        'b',
+        'YES',
+        12,
+        6,
+        'problem',
+        'hint',
+        'translation',
+        'source'
+      ),
+    ];
+    expect(convertSegmentAnswerToGapAnswer(segmentAnswer)).toEqual(
+      expectedResult
+    );
+  });
+});

--- a/src/routes/__tests__/exportdata.test.ts
+++ b/src/routes/__tests__/exportdata.test.ts
@@ -1,8 +1,11 @@
-import { convertSegmentAnswerToGapAnswer } from '../exportData';
+import {
+  convertSegmentAnswerToGapAnswer,
+  removeDuplicateAnswers,
+} from '../exportData';
 import { SegmentAnswer, GapAnswer } from '../../models/models';
 
 describe('convertSegmentAnswerToGapAnswer', () => {
-  test('', () => {
+  test('should convert segment answer to gap fill answers', () => {
     const segmentAnswer = new SegmentAnswer(
       'segmentId',
       'evaluatorId1',
@@ -58,5 +61,88 @@ describe('convertSegmentAnswerToGapAnswer', () => {
     expect(convertSegmentAnswerToGapAnswer(segmentAnswer)).toEqual(
       expectedResult
     );
+  });
+});
+
+describe('removeDuplicateAnswers', () => {
+  test('should remove duplicate old answers from segments', () => {
+    const segmentId1AnswerDuplicate = new SegmentAnswer(
+      'segmentId1',
+      'evaluatorId1',
+      ['a', 'b'],
+      12,
+      'sourceLanguage',
+      'translationSystem',
+      ['a', 'b'],
+      'hint',
+      'problem',
+      'source',
+      'translation',
+      'answerId',
+      200
+    );
+
+    const segmentId1AnswerEarliest = new SegmentAnswer(
+      'segmentId1',
+      'evaluatorId1',
+      ['c', 'd'],
+      12,
+      'sourceLanguage',
+      'translationSystem',
+      ['a', 'b'],
+      'hint',
+      'problem',
+      'source',
+      'translation',
+      'answerId',
+      100
+    );
+
+    const segmentId1Answer = new SegmentAnswer(
+      'segmentId1',
+      'evaluatorId2',
+      ['a', 'b'],
+      12,
+      'sourceLanguage',
+      'translationSystem',
+      ['a', 'b'],
+      'hint',
+      'problem',
+      'source',
+      'translation',
+      'answerId',
+      123
+    );
+
+    const segmentId2Answer = new SegmentAnswer(
+      'segmentId2',
+      'evaluatorId1',
+      ['a', 'b'],
+      12,
+      'sourceLanguage',
+      'translationSystem',
+      ['a', 'b'],
+      'hint',
+      'problem',
+      'source',
+      'translation',
+      'answerId',
+      123
+    );
+
+    const segmentAnswers = [
+      segmentId1AnswerDuplicate,
+      segmentId1AnswerEarliest,
+      segmentId1Answer,
+      segmentId2Answer,
+    ];
+
+    const expectedResult = [
+      segmentId1AnswerEarliest,
+      segmentId1Answer,
+      segmentId2Answer,
+    ];
+
+    expect(removeDuplicateAnswers(segmentAnswers)).toEqual(expectedResult);
   });
 });

--- a/src/routes/exportData.ts
+++ b/src/routes/exportData.ts
@@ -147,22 +147,14 @@ const createAnswersCSVFile = (
 };
 
 const removeDuplicateAnswers = (answers: SegmentAnswer[]): SegmentAnswer[] => {
-  const answersGroupedBySegmentId = groupBy<SegmentAnswer>(
-    answers,
-    'segmentId'
-  );
   const segmentGroupsBySegmentId: SegmentAnswer[][] = Object.values(
-    answersGroupedBySegmentId
+    groupBy<SegmentAnswer>(answers, 'segmentId')
   );
 
   const filteredSegmentAnswers: SegmentAnswer[][] = segmentGroupsBySegmentId.map(
     segment => {
-      const segmentsGroupedByEvaluatorId = groupBy<SegmentAnswer>(
-        segment,
-        'evaluatorId'
-      );
       const segmentGroupsByEvaluatorId: SegmentAnswer[][] = Object.values(
-        segmentsGroupedByEvaluatorId
+        groupBy<SegmentAnswer>(segment, 'evaluatorId')
       );
       const segmentAnswers: SegmentAnswer[] = segmentGroupsByEvaluatorId.map(
         segmentAnswer => {


### PR DESCRIPTION
Problem: some evaluators accidentally evaluate the same sentence more than once. If this happens when exporting data we should only export the sentence with the earliest timestamp

- previously each segment was assigned an additional human readable Id, this has now been removed
- segment answers are sorted and duplicates with later timestamps are removed