### PR TITLE
Enable password protection on pages where evaluation data is viewed or edited

### DIFF
--- a/docs/admin.md
+++ b/docs/admin.md
@@ -66,7 +66,7 @@ There are also optional parameters that can be provided to enable basic user aut
 3. The Gap Fill App will now be running on [http://localhost:8080](http:localhost:8080) using the DynamoDB created in AWS for storage.
 
 ## Security
-The software comes with optional [basic access authentication](https://en.wikipedia.org/wiki/Basic_access_authentication). This is enabled via the `ENABLE_AUTH` environment variable. If it is set to true when the user tries to access the site they will be presented with a login pop up. Once the user has logged in they will be able to freely access all of the site.
+The software comes with optional [basic access authentication](https://en.wikipedia.org/wiki/Basic_access_authentication). This is enabled via the `ENABLE_AUTH` environment variable. If it is set to true when the user tries to access pages on the site that allow them to view or submit evaluation data they will be presented with a login pop up. They will only need to login once. Once the user has logged in they will be able to freely access all of the site.
 ![](./images/login.png)
 The `USERNAME` and `PASSWORD` environment variables must also be specified via environment variables. The docker command to run a container with authentication is:
 ```docker run -p 8080:8080 -e AWS_ACCESS_KEY_ID=AWS_KEY_ID -e AWS_SECRET_ACCESS_KEY=AWS_SECRET_ACCESS_KEY -e ENABLE_AUTH=true -e USERNAME=admin -e PASSWORD=strongpassword  newslabsgourmet/gap-fill-tool```

--- a/docs/development.md
+++ b/docs/development.md
@@ -100,3 +100,13 @@ The Docker image is hosted on [Dockerhub](https://hub.docker.com/r/newslabsgourm
 ```
 docker push newslabsgourmet/gap-fill-tool:CURRENT_VERSION_NUMBER
 ```
+
+## Log In and Secure Router
+
+The application allows users to view and submit evaluation data. The BBC use case requires users from multiple organisations to access this tool. All pages that should only be available to authorized users are protected using [basic access authentication](https://en.wikipedia.org/wiki/Basic_access_authentication) which requires a user to provide a username and password before accessing a page.
+
+### Implementation
+
+The `/auth` path of the application is password protected using the [`express-basic-auth`](https://www.npmjs.com/package/express-basic-auth) library. The [secure router](../src/utils/secureRouter.ts) implements the basic auth and is used to serve password protected sub paths e.g. `/auth/evaluation`, `\auth\feedback` etc. so that multiple pages can be password protected.
+
+Authentication of the app is turned on and off by setting the `ENABLE_AUTH` environment variable to 'true' or 'false'. The username and password are set using the environment variables `USERNAME` and `PASSWORD`.

--- a/src/app.ts
+++ b/src/app.ts
@@ -2,7 +2,7 @@ import * as express from 'express';
 import { Application } from 'express';
 import * as multer from 'multer';
 import { Instance } from 'multer';
-import * as basicAuth from 'express-basic-auth';
+import secureRouter from './utils/secureRouter';
 
 import { buildIndexRoute } from './routes/index';
 import { buildInstructionsRoute } from './routes/instructions';
@@ -22,46 +22,27 @@ import { logger } from './utils/logger';
 const app: Application = express();
 const port = process.env.PORT || 8080;
 
-// support parsing of application/json type post data
-app.use(express.json());
-// support parsing of application/x-www-form-urlencoded post data
-app.use(express.urlencoded({ extended: true }));
 // Serve static assets in the public folder
 app.use(express.static('public'));
+// Enable password authentication on any path starting with /auth
+app.use('/auth', secureRouter);
 // Use handlebars to render templates
 app.set('view engine', 'hbs');
 // Instantiate multer for uploads
 const upload: Instance = multer({ dest: 'uploads/' });
-// Enable Log in
-if (process.env.ENABLE_AUTH === 'true') {
-  if (
-    process.env.PASSWORD === undefined ||
-    process.env.USERNAME === undefined
-  ) {
-    throw new Error(
-      'Log in cannot be enabled on the tool unless a password and username are specified in the config.'
-    );
-  } else {
-    app.use(
-      basicAuth({
-        users: { [process.env.USERNAME]: process.env.PASSWORD },
-        challenge: true, // To show login UI
-      })
-    );
-  }
-}
 
 buildIndexRoute(app);
 buildInstructionsRoute(app);
-buildStartRoute(app);
-buildBeginEvaluationRoute(app);
-buildEvaluationRoutes(app);
 buildEndRoute(app);
-buildStatusRoute(app);
-buildDatasetRoutes(app, upload);
 buildSuccessRoute(app);
-buildExportDataRoutes(app);
 buildErrorRoute(app);
+buildStatusRoute(app);
+
+buildStartRoute(secureRouter);
+buildBeginEvaluationRoute(secureRouter);
+buildEvaluationRoutes(secureRouter);
+buildDatasetRoutes(secureRouter, upload);
+buildExportDataRoutes(secureRouter);
 
 app.listen(port, () => {
   logger.info(`App running on port ${port}`);

--- a/src/routes/beginEvaluation.ts
+++ b/src/routes/beginEvaluation.ts
@@ -1,11 +1,11 @@
-import { Response, Application } from 'express';
+import { Response, Router } from 'express';
 import { putSegmentSet, getSegmentSets } from '../dynamoDb/api';
 import { StartRequest } from '../models/requests';
 import { SegmentSet } from '../models/models';
 import { logger } from '../utils/logger';
 
-const buildBeginEvaluationRoute = (app: Application) => {
-  app.post('/beginEvaluation', (req: StartRequest, res: Response) => {
+const buildBeginEvaluationRoute = (router: Router) => {
+  router.post('/beginEvaluation', (req: StartRequest, res: Response) => {
     const setName = req.body.setName;
     findSet(setName)
       .then(segmentSet => {
@@ -16,7 +16,7 @@ const buildBeginEvaluationRoute = (app: Application) => {
               segmentSet.segmentIds || new Set()
             );
             res.redirect(
-              `/evaluation?setId=${segmentSet.setId}&evaluatorId=${evaluatorId}&setSize=${segmentIdsList.length}&segmentNum=0`
+              `/auth/evaluation?setId=${segmentSet.setId}&evaluatorId=${evaluatorId}&setSize=${segmentIdsList.length}&segmentNum=0`
             );
           })
           .catch(error => {

--- a/src/routes/dataset.ts
+++ b/src/routes/dataset.ts
@@ -1,4 +1,4 @@
-import { Application, Request, Response } from 'express';
+import { Router, Request, Response } from 'express';
 import { Instance } from 'multer';
 import { readFileSync, unlink } from 'fs';
 import { DatasetFile, SegmentSet } from '../models/models';
@@ -6,12 +6,12 @@ import { DatasetRequest } from '../models/requests';
 import { putSegment, putSegmentSet } from '../dynamoDb/api';
 import { logger } from '../utils/logger';
 
-const buildDatasetRoutes = (app: Application, upload: Instance) => {
-  app.get('/dataset', (req: Request, res: Response) => {
+const buildDatasetRoutes = (router: Router, upload: Instance) => {
+  router.get('/dataset', (req: Request, res: Response) => {
     res.render('dataset');
   });
 
-  app.post(
+  router.post(
     '/dataset',
     upload.single('dataset'),
     (req: DatasetRequest, res: Response) => {

--- a/src/routes/evaluation.ts
+++ b/src/routes/evaluation.ts
@@ -1,4 +1,4 @@
-import { Request, Response, Application } from 'express';
+import { Request, Response, Router } from 'express';
 import { getSegmentSet, getSegment, putSegmentAnswers } from '../dynamoDb/api';
 import {
   SegmentEvaluationRequest,
@@ -11,8 +11,8 @@ import {
 } from '../utils';
 import { logger } from '../utils/logger';
 
-const buildEvaluationRoutes = (app: Application) => {
-  app.post('/evaluation', (req: SegmentEvaluationRequest, res: Response) => {
+const buildEvaluationRoutes = (router: Router) => {
+  router.post('/evaluation', (req: SegmentEvaluationRequest, res: Response) => {
     const body: SegmentEvaluationRequestBody = req.body;
     const setId: string = body.setId;
     const evaluatorId: string = body.evaluatorId;
@@ -43,7 +43,7 @@ const buildEvaluationRoutes = (app: Application) => {
     )
       .then(() =>
         res.redirect(
-          `/evaluation?setId=${setId}&evaluatorId=${evaluatorId}&setSize=${setSize}&segmentNum=${segmentNum}`
+          `/auth/evaluation?setId=${setId}&evaluatorId=${evaluatorId}&setSize=${setSize}&segmentNum=${segmentNum}`
         )
       )
       .catch(error => {
@@ -54,7 +54,7 @@ const buildEvaluationRoutes = (app: Application) => {
       });
   });
 
-  app.get('/evaluation', (req: Request, res: Response) => {
+  router.get('/evaluation', (req: Request, res: Response) => {
     const setId = req.query.setId;
     const evaluatorId = req.query.evaluatorId;
     const setSize = Number(req.query.setSize || 0);

--- a/src/routes/exportData.ts
+++ b/src/routes/exportData.ts
@@ -1,4 +1,4 @@
-import { Application, Request, Response } from 'express';
+import { Router, Request, Response } from 'express';
 import { ExportRequest } from '../models/requests';
 import { getSegmentAnswers, getSegmentSets } from '../dynamoDb/api';
 import {
@@ -13,13 +13,13 @@ import { createObjectCsvWriter } from 'csv-writer';
 import { groupBy, flatten, sortBy } from 'underscore';
 import { logger } from '../utils/logger';
 
-const buildExportDataRoutes = (app: Application) => {
-  getExportData(app);
-  postExportData(app);
+const buildExportDataRoutes = (router: Router) => {
+  getExportData(router);
+  postExportData(router);
 };
 
-const getExportData = (app: Application) => {
-  app.get('/exportData', (req: Request, res: Response) => {
+const getExportData = (router: Router) => {
+  router.get('/exportData', (req: Request, res: Response) => {
     getSegmentSets()
       .then(segmentSets => {
         const evaluatorSets = segmentSets
@@ -59,8 +59,8 @@ const convertSegmentSetToEvaluatorSet = (
   };
 };
 
-const postExportData = (app: Application) => {
-  app.post('/exportData', (req: ExportRequest, res: Response) => {
+const postExportData = (router: Router) => {
+  router.post('/exportData', (req: ExportRequest, res: Response) => {
     const language: string = req.body.language;
     if (language === undefined) {
       logger.error(`Language not provided on POST request to export data`);

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -12,8 +12,8 @@ const buildIndexRoute = (app: Application) => {
         'If you are happy to proceed please click ‘OK’.',
       ],
       formSubmissionUrl: '/instructions',
-      datasetSubmissionUrl: '/dataset',
-      exportDataUrl: '/exportData',
+      datasetSubmissionUrl: '/auth/dataset',
+      exportDataUrl: '/auth/exportData',
     });
   });
 };

--- a/src/routes/instructions.ts
+++ b/src/routes/instructions.ts
@@ -12,9 +12,9 @@ const buildInstructionsRoute = (app: Application) => {
         'If you have no hint and no clear idea just give it your best shot. Please try to make a sentence you think may have been published and avoid using words you know or suspect are not correct just because it will give an amusing outcome!',
         'If you have read the above and are happy to proceed please click ‘OK’.',
       ],
-      formSubmissionUrl: '/start',
-      datasetSubmissionUrl: '/dataset',
-      exportDataUrl: '/exportData',
+      formSubmissionUrl: '/auth/start',
+      datasetSubmissionUrl: '/auth/dataset',
+      exportDataUrl: '/auth/exportData',
     });
   });
 };

--- a/src/routes/start.ts
+++ b/src/routes/start.ts
@@ -1,9 +1,9 @@
-import { Application, Request, Response } from 'express';
+import { Request, Response, Router } from 'express';
 import { getSegmentSets } from '../dynamoDb/api';
 import { logger } from '../utils/logger';
 
-const buildStartRoute = (app: Application) => {
-  app.get('/start', (req: Request, res: Response) => {
+const buildStartRoute = (router: Router) => {
+  router.get('/start', (req: Request, res: Response) => {
     const setName = req.query.setName;
     getSegmentSets()
       .then(segmentSets => {

--- a/src/routes/success.ts
+++ b/src/routes/success.ts
@@ -5,7 +5,7 @@ const buildSuccessRoute = (app: Application) => {
     res.render('infoButtonGeneric', {
       title: 'Successfully Submitted Dataset',
       subtitle: '',
-      url: '/dataset',
+      url: '/auth/dataset',
       buttonText: 'Submit another data set',
     });
   });

--- a/src/utils/secureRouter.ts
+++ b/src/utils/secureRouter.ts
@@ -1,0 +1,34 @@
+import * as express from 'express';
+import { Router } from 'express';
+import * as basicAuth from 'express-basic-auth';
+import '../config';
+
+const secureRouter: Router = Router();
+
+// support parsing of application/x-www-form-urlencoded post data
+secureRouter.use(express.urlencoded({ extended: true }));
+// support parsing of application/json type post data
+secureRouter.use(express.json());
+// Serve static assets in the public folder
+secureRouter.use(express.static('public'));
+
+// Enable Log in
+if (process.env.ENABLE_AUTH) {
+  if (
+    process.env.PASSWORD === undefined ||
+    process.env.USERNAME === undefined
+  ) {
+    throw new Error(
+      'Log in cannot be enabled on the tool unless a password and username are specified in the config.'
+    );
+  } else {
+    secureRouter.use(
+      basicAuth({
+        users: { [process.env.USERNAME]: process.env.PASSWORD },
+        challenge: true, // To show login UI
+      })
+    );
+  }
+}
+
+export default secureRouter;

--- a/views/dataset.hbs
+++ b/views/dataset.hbs
@@ -58,7 +58,7 @@
                         }
                         </code>
                     </pre>
-                    <form action="/dataset"
+                    <form action="/auth/dataset"
                           method="POST"
                           enctype="multipart/form-data">
                         <div class="form-row align-bottom">

--- a/views/evaluation.hbs
+++ b/views/evaluation.hbs
@@ -41,7 +41,7 @@
                     <div class="evaluation__form">
                         <div class="row margin-top-5percent">
                             <div class="col">
-                                <form action="/evaluation"
+                                <form action="/auth/evaluation"
                                       method="POST">
                                     <div class="row">
                                         <div class="col-sm-1">

--- a/views/start.hbs
+++ b/views/start.hbs
@@ -35,7 +35,7 @@
                         </div>
                     </div>
                     <form class="text-primary-dark-grey"
-                          action="/beginEvaluation"
+                          action="/auth/beginEvaluation"
                           method="POST">
                         <div class="row justify-content-center form-group">
                             <div class="col-md-6">
@@ -47,9 +47,9 @@
                                        list="setName-values"
                                        class="form-control"
                                        onblur="javascript:location.search = '?setName=' + this.value;"
-                                       {{#if setName}}value="{{setName}}"{{/if}}
-                                       required
-                                       >
+                                       {{#if setName}}value="{{setName}}"
+                                       {{/if}}
+                                       required>
                                 <datalist id="setName-values">
                                     {{#each segmentSets}}
                                     <option value="{{this.name}}">{{this.name}}</option>
@@ -64,7 +64,8 @@
                                         class="form-control"
                                         name="evaluatorId"
                                         required>
-                                    <option disabled selected>Pick an evaluator ID</option>
+                                    <option disabled
+                                            selected>Pick an evaluator ID</option>
                                     {{#each possibleEvaluatorIds}}
                                     <option value={{this}}>{{this}}</option>
                                     {{/each}}


### PR DESCRIPTION
What's changed:
- Use express router to require log in on pages where evaluation data can be viewed or modified. This approach allows the use of basic auth which is quicker and simpler to implement than a full log in system whilst still having roots that should not be password protected e.g. the `/status` root for healthchecks
- This works by requiring passwords on all paths that are a subpath of `/auth`